### PR TITLE
Add support for the section orientation tag.

### DIFF
--- a/examples/Demo/Demo.csproj
+++ b/examples/Demo/Demo.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Demo/Demo.csproj
+++ b/examples/Demo/Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;net40;net46;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netstandard1.4</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/examples/Demo/Program.cs
+++ b/examples/Demo/Program.cs
@@ -84,7 +84,7 @@ namespace Demo
                 Console.WriteLine();
             }
 
-            Console.ReadLine();
+           // Console.ReadLine();
         }
     }
 }

--- a/examples/Demo/Resources/WhatIUsed.html
+++ b/examples/Demo/Resources/WhatIUsed.html
@@ -1,0 +1,50 @@
+﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+
+    <p>
+        An ordered list:
+        <ol>
+            <li>Coffee</li>
+            <li>Tea</li>
+            <li>
+                Milk
+                <ul>
+                    <li>Coffee</li>
+                    <li>
+                        Tea
+                        <ol>
+                            <li>Earl Grey</li>
+                            <li>Green</li>
+                            <li>Rosboh</li>
+                        </ol>
+                    </li>
+                    <li>Milk</li>
+                </ul>
+            </li>
+            <li>Wine</li>
+        </ol>
+    </p>
+
+    <p style="section-orientation-after: landscape">delta parameter (<span style='font-family:Symbol'>d</span>)</p>
+
+    <p style="section-orientation-after: portrait">
+        If you like it, add me a rating on <a href="http://notesforhtml2openxml.codeplex.com">codeplex</a>
+    </p>
+
+    <div>
+        Hello !
+        je suis du texte
+        <span style="font-style: oblique">écrit en oblique.</span>
+    </div>
+    <div style="font-size:20">
+        asdasd
+    </div>
+    <!--<div style="page-break-before: always">
+    New page
+    </div>-->
+</body>
+</html>

--- a/src/Html2OpenXml/HtmlConverter.cs
+++ b/src/Html2OpenXml/HtmlConverter.cs
@@ -121,80 +121,80 @@ namespace HtmlToOpenXml
 			return paragraphs;
 		}
 
-		/// <summary>
-		/// Start the parse processing and append the converted paragraphs into the Body of the document.
-		/// </summary>
-		public void ParseHtml(String html) {
-			// This method exists because we may ensure the SectionProperties remains the last element of the body.
-			// It's mandatory when dealing with page orientation
+        /// <summary>
+        /// Start the parse processing and append the converted paragraphs into the Body of the document.
+        /// </summary>
+        public void ParseHtml(String html) {
+            // This method exists because we may ensure the SectionProperties remains the last element of the body.
+            // It's mandatory when dealing with page orientation
 
-			var paragraphs = Parse(html);
+            var paragraphs = Parse(html);
 
-			Body body = mainPart.Document.Body;
-			SectionProperties initialSectionProperties = mainPart.Document.Body.GetLastChild<SectionProperties>();
-			var firstOrientationChange = Orientation.Keys.FirstOrDefault();
-			var lastOrienationChange = Orientation.Keys.FirstOrDefault();
-			var singleOrientationChange =  Orientation.Keys.Count == 1;
+            Body body = mainPart.Document.Body;
+            SectionProperties initialSectionProperties = mainPart.Document.Body.GetLastChild<SectionProperties>();
+            var firstOrientationChange = Orientation.Keys.FirstOrDefault();
+            var lastOrienationChange = Orientation.Keys.LastOrDefault();
+            var singleOrientationChange = Orientation.Keys.Count == 1;
 
-			if (Orientation.Keys.Count > 0) {
+            if (Orientation.Keys.Count == 0) {
                 firstOrientationChange = -1;
                 lastOrienationChange = -1;
             }
 
-			var singleSectionOrientation = initialSectionProperties.CloneNode(true);
-			if (singleOrientationChange) {
-				singleSectionOrientation = Orientation[lastOrienationChange] ? ChangePageOrientation(PageOrientationValues.Landscape)
-																				: ChangePageOrientation(PageOrientationValues.Portrait);
-			}
-			for (int i = 0; i < paragraphs.Count; i++) {
-				var paragraph = paragraphs[i];
-				if (i == firstOrientationChange - 1) {
-					paragraph.PrependChild(new ParagraphProperties(new KeepLines(), initialSectionProperties.CloneNode(true)));
-					body.Append(paragraph);
-					continue;
-				}
-				if (i == lastOrienationChange && !singleOrientationChange) {
-					//paragraph.AppendChild(new ParagraphProperties(new KeepLines(), initialSectionProperties.CloneNode(true)));
-					body.Append(paragraph);
-					continue;
-				}
+            var singleSectionOrientation = initialSectionProperties.CloneNode(true);
+            if (singleOrientationChange) {
+                singleSectionOrientation = Orientation[lastOrienationChange] ? ChangePageOrientation(PageOrientationValues.Landscape)
+                                                                                : ChangePageOrientation(PageOrientationValues.Portrait);
+            }
+            for (int i = 0; i < paragraphs.Count; i++) {
+                var paragraph = paragraphs[i];
+                if (i == firstOrientationChange - 1) {
+                    paragraph.PrependChild(new ParagraphProperties(new KeepLines(), initialSectionProperties.CloneNode(true)));
+                    body.Append(paragraph);
+                    continue;
+                }
+                if (i == lastOrienationChange && !singleOrientationChange) {
+                    //paragraph.AppendChild(new ParagraphProperties(new KeepLines(), initialSectionProperties.CloneNode(true)));
+                    body.Append(paragraph);
+                    continue;
+                }
 
-				if (i >= lastOrienationChange && singleOrientationChange) {
-					paragraph.PrependChild(new ParagraphProperties(new KeepLines(), singleSectionOrientation.CloneNode(true)));
-					body.Append(paragraph);
-					continue;
-				}
+                if (i >= lastOrienationChange && singleOrientationChange) {
+                    paragraph.PrependChild(new ParagraphProperties(new KeepLines(), singleSectionOrientation.CloneNode(true)));
+                    body.Append(paragraph);
+                    continue;
+                }
 
-				if (!Orientation.TryGetValue(i, out var landscape)) {
-					body.Append(paragraph);
-					continue;
-				}
-				var pProps = paragraph.GetFirstChild<ParagraphProperties>();
-				if (pProps is null) {
-					var orientation = landscape ? PageOrientationValues.Landscape : PageOrientationValues.Portrait;
-					paragraph.PrependChild(new ParagraphProperties(new KeepLines(), ChangePageOrientation(orientation)));
-					body.Append(paragraph);
-					continue;
-				}
+                if (!Orientation.TryGetValue(i, out var landscape)) {
+                    body.Append(paragraph);
+                    continue;
+                }
+                var pProps = paragraph.GetFirstChild<ParagraphProperties>();
+                if (pProps is null) {
+                    var orientation = landscape ? PageOrientationValues.Landscape : PageOrientationValues.Portrait;
+                    paragraph.PrependChild(new ParagraphProperties(new KeepLines(), ChangePageOrientation(orientation)));
+                    body.Append(paragraph);
+                    continue;
+                }
 
-			}
-			//Push the sectionProperties as the last element of the Body
-			//(required by OpenXml schema to avoid the bad formatting of the document)
-			//if (singleSectionOrientation != null) {
-			//    var lastParagraph=body.GetLastChild<Paragraph>();
-			//    lastParagraph.Remove();
-			//    lastParagraph.PrependChild(new ParagraphProperties(singleSectionOrientation.CloneNode(true)));
-			//    body.Append(lastParagraph);
-			//}
-		}
+            }
+            //Push the sectionProperties as the last element of the Body
+            //(required by OpenXml schema to avoid the bad formatting of the document)
+            //if (singleSectionOrientation != null) {
+            //    var lastParagraph=body.GetLastChild<Paragraph>();
+            //    lastParagraph.Remove();
+            //    lastParagraph.PrependChild(new ParagraphProperties(singleSectionOrientation.CloneNode(true)));
+            //    body.Append(lastParagraph);
+            //}
+        }
 
-		#region RemoveEmptyParagraphs
+        #region RemoveEmptyParagraphs
 
-		/// <summary>
-		/// Remove empty paragraph unless 2 tables are side by side.
-		/// These paragraph could be empty due to misformed html or spaces in the html source.
-		/// </summary>
-		private void RemoveEmptyParagraphs()
+        /// <summary>
+        /// Remove empty paragraph unless 2 tables are side by side.
+        /// These paragraph could be empty due to misformed html or spaces in the html source.
+        /// </summary>
+        private void RemoveEmptyParagraphs()
 		{
 			bool hasRuns;
 
@@ -762,16 +762,16 @@ namespace HtmlToOpenXml
 			htmlStyles.PrepareStyles(mainPart);
 		}
 
-		#endregion
+        #endregion
 
-		#region ProcessContainerAttributes
+        #region ProcessContainerAttributes
 
-		/// <summary>
-		/// There is a few attributes shared by a large number of tags. This method will check them for a limited
-		/// number of tags (&lt;p&gt;, &lt;pre&gt;, &lt;div&gt;, &lt;span&gt; and &lt;body&gt;).
-		/// </summary>
-		/// <returns>Returns true if the processing of this tag should generate a new paragraph.</returns>
-		private bool ProcessContainerAttributes(HtmlEnumerator en, IList<OpenXmlElement> styleAttributes) {
+        /// <summary>
+        /// There is a few attributes shared by a large number of tags. This method will check them for a limited
+        /// number of tags (&lt;p&gt;, &lt;pre&gt;, &lt;div&gt;, &lt;span&gt; and &lt;body&gt;).
+        /// </summary>
+        /// <returns>Returns true if the processing of this tag should generate a new paragraph.</returns>
+        private bool ProcessContainerAttributes(HtmlEnumerator en, IList<OpenXmlElement> styleAttributes) {
             bool newParagraph = false;
 
             // Not applicable to a table : page break
@@ -815,17 +815,17 @@ namespace HtmlToOpenXml
 
             newParagraph |= htmlStyles.Paragraph.ProcessCommonAttributes(en, styleAttributes);
             return newParagraph;
-}
-        
+        }
 
-		#endregion
 
-		#region ChangePageOrientation
+        #endregion
 
-		/// <summary>
-		/// Generate the required OpenXml element for handling page orientation.
-		/// </summary>
-		private static SectionProperties ChangePageOrientation(PageOrientationValues orientation)
+        #region ChangePageOrientation
+
+        /// <summary>
+        /// Generate the required OpenXml element for handling page orientation.
+        /// </summary>
+        private static SectionProperties ChangePageOrientation(PageOrientationValues orientation)
 		{
 			PageSize pageSize = new PageSize() { Width = (UInt32Value) 16838U, Height = (UInt32Value) 11906U };
 			if (orientation == PageOrientationValues.Portrait)

--- a/src/Html2OpenXml/HtmlToOpenXml.csproj
+++ b/src/Html2OpenXml/HtmlToOpenXml.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;net40;net46;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netstandard1.4</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyName>HtmlToOpenXml</AssemblyName>

--- a/src/Html2OpenXml/HtmlToOpenXml.csproj
+++ b/src/Html2OpenXml/HtmlToOpenXml.csproj
@@ -71,7 +71,7 @@ You can see release note here: https://github.com/onizet/html2openxml/releases
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
+++ b/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We are using a dictionary to keep track of the page changes. It works in conjunction with the page-orientation tag. You are not supposed to use the page-break in conjunction with the section-orientation-after tag as the section break already accomplishes this.