### PR TITLE
Add support for section breaks and orientation changes.

### DIFF
--- a/examples/Demo/Demo.csproj
+++ b/examples/Demo/Demo.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;net40;net46;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netstandard1.4</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
 
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/Demo/Program.cs
+++ b/examples/Demo/Program.cs
@@ -14,7 +14,7 @@ namespace Demo
         static void Main(string[] args)
         {
             const string filename = "test.docx";
-            string html = ResourceHelper.GetString("Resources.CompleteRunTest.html");
+            string html = ResourceHelper.GetString("Resources.WhatIUsed.html");
             if (File.Exists(filename)) File.Delete(filename);
 
             using (MemoryStream generatedDocument = new MemoryStream())
@@ -22,10 +22,10 @@ namespace Demo
                 // Uncomment and comment the second using() to open an existing template document
                 // instead of creating it from scratch.
 
-                using (var buffer = ResourceHelper.GetStream("Resources.template.docx")) buffer.CopyToAsync(generatedDocument);
-                generatedDocument.Position = 0L;
-                using (WordprocessingDocument package = WordprocessingDocument.Open(generatedDocument, true))
-                //using (WordprocessingDocument package = WordprocessingDocument.Create(generatedDocument, WordprocessingDocumentType.Document))
+                //using (var buffer = ResourceHelper.GetStream("Resources.template.docx")) buffer.CopyToAsync(generatedDocument);
+                //generatedDocument.Position = 0L;
+                //using (WordprocessingDocument package = WordprocessingDocument.Open(generatedDocument, true))
+                using (WordprocessingDocument package = WordprocessingDocument.Create(generatedDocument, WordprocessingDocumentType.Document))
                 {
                     MainDocumentPart mainPart = package.MainDocumentPart;
                     if (mainPart == null)

--- a/examples/Demo/Resources/WhatIUsed.html
+++ b/examples/Demo/Resources/WhatIUsed.html
@@ -1,0 +1,52 @@
+﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+    <p section-orientation="current landscape">this should be the first line in the landscape orientation.</p>
+    <p section-orientation="current portrait">this should be the first line in the portrait orientation.</p>
+
+    <p>
+        An ordered list:
+        <ol>
+            <li>Coffee</li>
+            <li>Tea</li>
+            <li>
+                Milk
+                <ul>
+                    <li>Coffee</li>
+                    <li>
+                        Tea
+                        <ol>
+                            <li>Earl Grey</li>
+                            <li>Green</li>
+                            <li>Rosboh</li>
+                        </ol>
+                    </li>
+                    <li>Milk</li>
+                </ul>
+            </li>
+            <li>Wine</li>
+        </ol>
+    </p>
+
+    <p section-orientation="current landscape">this should be the first line in the landscape orientation.</p>
+
+    <p section-orientation="after portrait">
+        This should be the last line in the previous orientation (landscape).
+    </p>
+
+    <div>
+        This should be the first line in the portrait orientation.
+        <span style="font-style: oblique">écrit en oblique.</span>
+    </div>
+    <div section-orientation="landscape" style="font-size:20">
+        This should be the first line in the landscape orientation.
+        'current' should be the default and optional.
+    </div>
+    <!--<div style="page-break-before: always">
+    New page
+    </div>-->
+</body>
+</html>

--- a/src/Html2OpenXml/Collections/HtmlAttributeCollection.cs
+++ b/src/Html2OpenXml/Collections/HtmlAttributeCollection.cs
@@ -29,13 +29,13 @@ namespace HtmlToOpenXml
 		// RegexOptions.Singleline stands for dealing with attributes that contain newline (typically for base64 image, see issue #8)
 		private static Regex stripAttributesRegex = new Regex(@"
 #tag and its value surrounded by "" or '
-((?<tag>\w+)=(?<sep>""|')\s*(?<val>\#?.*?)(\k<sep>|>))
+((?<tag>(\w-?)+)=(?<sep>""|')\s*(?<val>\#?.*?)(\k<sep>|>))
 |
 # tag whereas the value is not delimited: cellspacing=0
-(?<tag>\w+)=(?<val>\w+)
+(?<tag>(\w-?)+)=(?<val>\w+)
 |
 # single tag (with no value): contenteditable
-\b(?<tag>\w+)\b", RegexOptions.IgnorePatternWhitespace| RegexOptions.Singleline);
+\b(?<tag>(\w-?)+)\b", RegexOptions.IgnorePatternWhitespace| RegexOptions.Singleline);
 
         private static Regex stripStyleAttributesRegex = new Regex(@"(?<name>.+?):\s*(?<val>[^;]+);*\s*");
 

--- a/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
+++ b/src/Html2OpenXml/HtmlConverter.ProcessTag.cs
@@ -127,23 +127,7 @@ namespace HtmlToOpenXml
 			string attr = en.StyleAttributes["page-orientation"];
 			if (attr != null)
 			{
-				PageOrientationValues orientation = Converter.ToPageOrientation(attr);
-
-                SectionProperties sectionProperties = mainPart.Document.Body.GetFirstChild<SectionProperties>();
-                if (sectionProperties == null || sectionProperties.GetFirstChild<PageSize>() == null)
-                {
-                    mainPart.Document.Body.Append(HtmlConverter.ChangePageOrientation(orientation));
-                }
-                else
-                {
-                    PageSize pageSize = sectionProperties.GetFirstChild<PageSize>();
-                    if (!pageSize.Compare(orientation))
-                    {
-                        SectionProperties validSectionProp = ChangePageOrientation(orientation);
-                        if (pageSize != null) pageSize.Remove();
-                        sectionProperties.PrependChild(validSectionProp.GetFirstChild<PageSize>().CloneNode(true));
-                    }
-                }
+				currentOrientation = Converter.ToPageOrientation(attr);
             }
 		}
 
@@ -203,7 +187,7 @@ namespace HtmlToOpenXml
 		{
 			// The way the browser consider <div> is like a simple Break. But in case of any attributes that targets
 			// the paragraph, we don't want to apply the style on the old paragraph but on a new one.
-			if (en.Attributes.Count == 0 || (en.StyleAttributes["text-align"] == null && en.Attributes["align"] == null && en.StyleAttributes.GetAsBorder("border").IsEmpty))
+			if (en.Attributes.Count == 0 || (en.StyleAttributes["text-align"] == null && en.Attributes["align"] == null && en.StyleAttributes.GetAsBorder("border").IsEmpty && en.Attributes["section-orientation"] == null))
 			{
 				List<OpenXmlElement> runStyleAttributes = new List<OpenXmlElement>();
 				bool newParagraph = ProcessContainerAttributes(en, runStyleAttributes);
@@ -621,6 +605,7 @@ namespace HtmlToOpenXml
 
 			List<OpenXmlElement> styleAttributes = new List<OpenXmlElement>();
 			bool newParagraph = ProcessContainerAttributes(en, styleAttributes);
+			ProcessSectionOrientation(en);
 
 			if (styleAttributes.Count > 0)
 				htmlStyles.Runs.BeginTag(en.CurrentTag, styleAttributes.ToArray());

--- a/src/Html2OpenXml/HtmlToOpenXml.csproj
+++ b/src/Html2OpenXml/HtmlToOpenXml.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.4</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net35;net40;net46;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net46;netstandard1.4</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyName>HtmlToOpenXml</AssemblyName>
@@ -71,7 +71,7 @@ You can see release note here: https://github.com/onizet/html2openxml/releases
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
+++ b/test/HtmlToOpenXml.Tests/HtmlToOpenXml.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.7.2" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is supported by providing the `section-orientation` attribute on a `<p>` or `<div>` tag.
+ The value of the attribute is composed of two parts:
  + The position where the new orientation will take effect. Allowed values: `current` or `after`. It is optional and defaults to `current`. When `current` is used, the current paragraph will be the first in the new section/orientation. When `after` is used the current paragraph will be the last in the current section/orientation.
  + The new orientation: `portrait` or `landscape`. It is required.

Upgrade DocumentFormat to 2.9.1.